### PR TITLE
Handle response without status

### DIFF
--- a/lib/UploadTask.js
+++ b/lib/UploadTask.js
@@ -184,6 +184,15 @@ function pollStatus(uid) {
                             this._config['INTERVAL'] * 1000
                         );
                 }
+            } else {
+               // In case response has no status
+               // (example: {"detail": "Enhance your calm."})
+               setTimeout(
+                   function pollRetry() {
+                       pollStatus.call(this, uid);
+                   }.bind(this),
+                   this._config['INTERVAL'] * 1000
+               );
             }
         }.bind(this)
     );


### PR DESCRIPTION
Thanks for the V3 update!
This is fixing a bug that already existed before I think.
Sometimes, API response can have no `status` key. Example: `{"detail": "Enhance your calm."}`. Then, we are not entering in any case. This can make the event loop to be empty, and the process to stop. And this also makes us never get out the upload part.

Now we continue polling.